### PR TITLE
upgrade GitHub workflow with new syntax

### DIFF
--- a/.github/workflows/github-page.yaml
+++ b/.github/workflows/github-page.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Get yarn cache
         id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
because set-output has been deprecated
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204547419615987